### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ r_flutter
 ====
 
 Generate constants for resources which require using them as a String like fonts and assets. Generated file will look like this:
-[assets.dart](/example/.dart_tool/build/generated/example/lib/assets.dart)
+[assets.dart](https://github.com/timfreiheit/r_flutter/blob/master/example/.dart_tool/build/generated/example/lib/assets.dart)
 
 ## Setup
 
@@ -94,4 +94,3 @@ you can write:
 ```dart
 await rootBundle.loadString(Assets.data)
 ```
-


### PR DESCRIPTION
Readme from https://pub.dev/packages/r_flutter to invalid location for assets.dart, which is not good, because clicking that link may be the first thing that new user would do.

This should fix the problem, but maybe there is a better way.